### PR TITLE
MerkleTree.New.High.Correct.Base: Bump rlimit

### DIFF
--- a/src/MerkleTree.New.High.Correct.Base.fst
+++ b/src/MerkleTree.New.High.Correct.Base.fst
@@ -382,7 +382,7 @@ val mt_hashes_inv_log_converted_:
         (decreases j)
 #pop-options
 
-#push-options "--z3rlimit 75 --initial_fuel 2 --max_fuel 2"
+#push-options "--z3rlimit 100 --initial_fuel 2 --max_fuel 2"
 let rec mt_hashes_inv_log_converted_ #_ #f lv j fhs =
   if j = 1 then ()
   else (log2c_bound (j / 2) (32 - (lv + 1));


### PR DESCRIPTION
From the commit message: 

    Unsure if this is really needed. Everest failed, but locally I got a green without this change, so bumping just in case.

Kicked another build. Maybe let's wait to see if this comes back green before merging https://github.com/project-everest/everest/actions/runs/7281300472